### PR TITLE
Match the __init__() signature of the static and generated modules

### DIFF
--- a/model/conv1d.py
+++ b/model/conv1d.py
@@ -82,7 +82,7 @@ class Conv1dStatic(nn.Module):
     """
     1D convolution with an independent kernel for each instrument
     """
-    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0, dilation=1, groups=1, bias=False):
+    def __init__(self, _, __, in_channels, out_channels, kernel_size, stride=1, padding=0, dilation=1, groups=1, bias=False):
         """
         Arguments:
             in_channels {int} -- Number of channels of the input

--- a/model/group_norm.py
+++ b/model/group_norm.py
@@ -70,11 +70,9 @@ class GroupNormStatic(nn.Module):
     """
     Group normalization layer with an independent scale and bias factor for each instrument
     """
-    def __init__(self, num_groups, num_channels, eps=1e-8):
+    def __init__(self, _, __, num_groups, num_channels, eps=1e-8):
         """
         Arguments:
-            E_1 {int} -- Dimension of the instrument embedding
-            E_2 {int} -- Dimension of the instrument embedding bottleneck
             num_groups {int} -- Number of normalized groups
             num_channels {int} -- Number of channels
 


### PR DESCRIPTION
Constructing the non-generated classes does not work at this moment due to unpacking of `*args`.